### PR TITLE
Merge MCP wire + request-client stack into next

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -12,6 +12,8 @@ import { getPlatformHeaders } from './internal/detect-platform';
 import * as Shims from './internal/shims';
 import * as Opts from './internal/request-options';
 import { stringifyQuery } from './internal/utils/query';
+import { prepareMcpRequest } from './lib/mcp';
+import type { JsonObject } from './lib/utils/json';
 import { VERSION } from './version';
 import * as Errors from './core/error';
 import * as Uploads from './core/uploads';
@@ -398,6 +400,14 @@ export class Dedalus {
    * We preserve the structured output schemas, which are already in the correct format.
    */
   protected async prepareOptions(options: FinalRequestOptions): Promise<void> {
+    // Encrypt MCP credentials before any other transforms
+    if (options.body && typeof options.body === 'object' && !Array.isArray(options.body)) {
+      const body = options.body as JsonObject;
+      if (body['credentials'] && body['mcp_servers']) {
+        options.body = await prepareMcpRequest(body, this.asBaseURL, this.fetch);
+      }
+    }
+
     if (options.body) {
       options.body = transformRequestBody(options.body);
     }

--- a/src/lib/mcp/index.ts
+++ b/src/lib/mcp/index.ts
@@ -22,4 +22,9 @@ export {
   serializeCredentials,
   serializeToolSpecs,
   serializeMcpServerWithCreds,
+  serializeConnection,
+  collectUniqueConnections,
+  matchCredentialsToConnections,
+  validateCredentialsForServers,
+  buildConnectionRecord,
 } from './wire';

--- a/src/lib/mcp/index.ts
+++ b/src/lib/mcp/index.ts
@@ -17,6 +17,7 @@ export {
   wireSpecToWire,
   wireSpecFromSlug,
   wireSpecFromUrl,
+  slugToConnectionName,
   serializeMcpServers,
   serializeSingle,
   serializeCredentials,
@@ -28,3 +29,10 @@ export {
   validateCredentialsForServers,
   buildConnectionRecord,
 } from './wire';
+
+export {
+  type EncryptedCredentials,
+  prepareMcpRequest,
+  encryptCredentialsList,
+  embedCredentials,
+} from './request';

--- a/src/lib/mcp/request.ts
+++ b/src/lib/mcp/request.ts
@@ -1,0 +1,146 @@
+/**
+ * MCP request preparation.
+ * Port of: dedalus-sdk-python/src/dedalus_labs/lib/mcp/request.py
+ *
+ * Handles client-side preparation of MCP requests:
+ * 1. Serializes MCPServer objects to wire format
+ * 2. Deep copies to protect retry logic from mutation
+ * 3. Encrypts credentials client-side before transmission
+ */
+
+import { type JsonObject } from '../utils/json';
+import { encryptCredentials, fetchEncryptionKey } from '../crypto/encryption';
+import { type CredentialProtocol } from './protocols';
+import { serializeMcpServers, slugToConnectionName, type MCPServerWireOutput } from './wire';
+
+/** Map of connection names to encrypted envelopes (base64url). */
+export interface EncryptedCredentials {
+  [connectionName: string]: string;
+}
+
+// --- Request Preparation ---
+
+/**
+ * Serialize mcp_servers, deep copy, and encrypt credentials.
+ *
+ * @param data - Request body dict.
+ * @param asUrl - Authorization server URL for fetching encryption key.
+ * @param fetchFn - Optional fetch implementation (defaults to global fetch).
+ * @returns A new dict with serialized servers and encrypted credentials.
+ */
+export async function prepareMcpRequest(
+  data: JsonObject,
+  asUrl?: string | null,
+  fetchFn?: typeof fetch,
+): Promise<JsonObject> {
+  // Serialize MCP servers, if provided.
+  const servers = data['mcp_servers'];
+  if (servers != null) {
+    data['mcp_servers'] = serializeMcpServers(servers as Parameters<typeof serializeMcpServers>[0]);
+  }
+
+  // Read credentials from original data BEFORE deep clone (functions survive)
+  const credentials = data['credentials'];
+
+  // If credentials are provided, encrypt them on the client side
+  if (credentials && servers && asUrl) {
+    const publicKey = await fetchEncryptionKey(asUrl, fetchFn);
+    const credList = Array.isArray(credentials) ? credentials : [credentials];
+    const encrypted = await encryptCredentialsList(credList, publicKey);
+
+    // Deep copy to avoid mutation side effects
+    const result = JSON.parse(JSON.stringify(data)) as JsonObject;
+
+    if (Object.keys(encrypted).length > 0) {
+      result['mcp_servers'] = embedCredentials(result['mcp_servers'] as MCPServerWireOutput[], encrypted);
+      delete result['credentials'];
+    }
+
+    return result;
+  }
+
+  // No encryption needed — just deep copy
+  return JSON.parse(JSON.stringify(data)) as JsonObject;
+}
+
+// --- Internal Helpers ---
+
+/**
+ * Encrypt each credential.
+ *
+ * Supports both CredentialProtocol objects (from dedalus_mcp) and
+ * plain {connection_name, values} dicts (API type format).
+ */
+export async function encryptCredentialsList(
+  credentials: unknown[],
+  publicKey: CryptoKey,
+): Promise<EncryptedCredentials> {
+  const encrypted: EncryptedCredentials = {};
+
+  for (const cred of credentials) {
+    if (cred == null || typeof cred !== 'object') continue;
+    const c = cred as JsonObject;
+
+    // Extract connection name
+    let connectionName: string | null = null;
+    if (c['connection'] != null && typeof c['connection'] === 'object') {
+      connectionName = (c['connection'] as JsonObject)['name'] as string | null;
+    } else if (typeof c['connection_name'] === 'string') {
+      connectionName = c['connection_name'];
+    }
+
+    // Extract values
+    let values: JsonObject | null = null;
+    if (typeof c['valuesForEncryption'] === 'function') {
+      values = (c as CredentialProtocol).valuesForEncryption();
+    } else if (c['values'] != null && typeof c['values'] === 'object') {
+      values = c['values'] as JsonObject;
+    }
+
+    if (connectionName && values) {
+      encrypted[connectionName] = await encryptCredentials(publicKey, values);
+    }
+  }
+
+  return encrypted;
+}
+
+/**
+ * Return the subset of encrypted credentials that belongs to a server, or null.
+ *
+ * Derives the connection name via slugToConnectionName and looks it up in the
+ * full encrypted map.
+ */
+function credentialsForServer(
+  name: string,
+  allCreds: EncryptedCredentials,
+): { [conn: string]: string } | null {
+  const conn = slugToConnectionName(name);
+  const blob = allCreds[conn];
+  return blob ? { [conn]: blob } : null;
+}
+
+/**
+ * Embed encrypted credentials into each server spec.
+ *
+ * Each server receives only its own credentials, matched by connection name
+ * via slugToConnectionName.
+ */
+export function embedCredentials(
+  servers: MCPServerWireOutput[],
+  encrypted: EncryptedCredentials,
+): JsonObject[] {
+  return servers.map((server) => {
+    if (typeof server === 'string') {
+      const creds = credentialsForServer(server, encrypted);
+      if (server.startsWith('http://') || server.startsWith('https://')) {
+        return { url: server, name: server, credentials: creds };
+      }
+      return { slug: server, name: server, credentials: creds };
+    }
+    // Existing spec dict → derive name and scope credentials
+    const name = (server['name'] ?? server['slug'] ?? server['url'] ?? '') as string;
+    const creds = credentialsForServer(name, encrypted);
+    return { ...server, name, credentials: creds };
+  });
+}

--- a/src/lib/mcp/request.ts
+++ b/src/lib/mcp/request.ts
@@ -10,7 +10,7 @@
 
 import { type JsonObject } from '../utils/json';
 import { encryptCredentials, fetchEncryptionKey } from '../crypto/encryption';
-import { type CredentialProtocol } from './protocols';
+import { type CryptoKey } from '../crypto/types';
 import { serializeMcpServers, slugToConnectionName, type MCPServerWireOutput } from './wire';
 
 /** Map of connection names to encrypted envelopes (base64url). */
@@ -79,12 +79,15 @@ export async function encryptCredentialsList(
 
   for (const cred of credentials) {
     if (cred == null || typeof cred !== 'object') continue;
-    const c = cred as JsonObject;
+    const c = cred as Record<string, unknown>;
 
     // Extract connection name
     let connectionName: string | null = null;
     if (c['connection'] != null && typeof c['connection'] === 'object') {
-      connectionName = (c['connection'] as JsonObject)['name'] as string | null;
+      const conn = c['connection'] as Record<string, unknown>;
+      if (typeof conn['name'] === 'string') {
+        connectionName = conn['name'];
+      }
     } else if (typeof c['connection_name'] === 'string') {
       connectionName = c['connection_name'];
     }
@@ -92,7 +95,7 @@ export async function encryptCredentialsList(
     // Extract values
     let values: JsonObject | null = null;
     if (typeof c['valuesForEncryption'] === 'function') {
-      values = (c as CredentialProtocol).valuesForEncryption();
+      values = (c['valuesForEncryption'] as () => JsonObject).call(c);
     } else if (c['values'] != null && typeof c['values'] === 'object') {
       values = c['values'] as JsonObject;
     }

--- a/src/lib/mcp/request.ts
+++ b/src/lib/mcp/request.ts
@@ -35,12 +35,16 @@ export async function prepareMcpRequest(
 ): Promise<JsonObject> {
   // Serialize MCP servers, if provided.
   const servers = data['mcp_servers'];
-  if (servers != null) {
-    data['mcp_servers'] = serializeMcpServers(servers as Parameters<typeof serializeMcpServers>[0]);
-  }
+  const serializedServers =
+    servers != null ? serializeMcpServers(servers as Parameters<typeof serializeMcpServers>[0]) : null;
 
   // Read credentials from original data BEFORE deep clone (functions survive)
   const credentials = data['credentials'];
+  // Deep copy to avoid mutation side effects
+  const result = JSON.parse(JSON.stringify(data)) as JsonObject;
+  if (serializedServers != null) {
+    result['mcp_servers'] = serializedServers;
+  }
 
   // If credentials are provided, encrypt them on the client side
   if (credentials && servers && asUrl) {
@@ -48,19 +52,15 @@ export async function prepareMcpRequest(
     const credList = Array.isArray(credentials) ? credentials : [credentials];
     const encrypted = await encryptCredentialsList(credList, publicKey);
 
-    // Deep copy to avoid mutation side effects
-    const result = JSON.parse(JSON.stringify(data)) as JsonObject;
-
     if (Object.keys(encrypted).length > 0) {
       result['mcp_servers'] = embedCredentials(result['mcp_servers'] as MCPServerWireOutput[], encrypted);
-      delete result['credentials'];
     }
+    delete result['credentials'];
 
     return result;
   }
 
-  // No encryption needed — just deep copy
-  return JSON.parse(JSON.stringify(data)) as JsonObject;
+  return result;
 }
 
 // --- Internal Helpers ---
@@ -98,7 +98,8 @@ export async function encryptCredentialsList(
     }
 
     if (connectionName && values) {
-      encrypted[connectionName] = await encryptCredentials(publicKey, values);
+      const normalizedConnectionName = slugToConnectionName(connectionName);
+      encrypted[normalizedConnectionName] = await encryptCredentials(publicKey, values);
     }
   }
 

--- a/src/lib/mcp/wire.ts
+++ b/src/lib/mcp/wire.ts
@@ -6,7 +6,12 @@
  */
 
 import { type JsonObject } from '../utils/json';
-import { type MCPServerProtocol, type CredentialProtocol, isMcpServer } from './protocols';
+import {
+  type MCPServerProtocol,
+  type MCPServerWithCredsProtocol,
+  type CredentialProtocol,
+  isMcpServer,
+} from './protocols';
 
 // --- Type Aliases ---
 
@@ -175,16 +180,16 @@ export function serializeToolSpecs(toolsService: unknown): Record<string, JsonOb
 }
 
 /** Serialize MCPServer with credentials for connection provisioning. */
-export function serializeMcpServerWithCreds(server: MCPServerProtocol): JsonObject {
+export function serializeMcpServerWithCreds(server: MCPServerWithCredsProtocol): JsonObject {
   const result: JsonObject = { name: server.name ?? 'unknown' };
 
-  const creds = (server as JsonObject)['credentials'];
+  const creds = server.credentials;
   if (creds != null) {
     const credsDict = serializeCredentials(creds);
     if (credsDict) result['credentials'] = credsDict;
   }
 
-  const connection = (server as JsonObject)['connection'];
+  const connection = server.connection;
   if (connection) result['connection'] = connection;
 
   return result;
@@ -303,11 +308,11 @@ export function validateCredentialsForServers(
 
 /** Build a connection record. */
 export function buildConnectionRecord(
-  server: MCPServerProtocol,
+  server: MCPServerWithCredsProtocol,
   credentials: Record<string, JsonObject>,
   orgId: string,
 ): JsonObject {
-  const connection = (server as JsonObject)['connection'] as string | null;
+  const connection = server.connection ?? null;
   let matchedCreds: JsonObject | null = null;
   if (connection && connection in credentials) {
     matchedCreds = credentials[connection]!;
@@ -316,7 +321,7 @@ export function buildConnectionRecord(
   return {
     org_id: orgId,
     connection,
-    credentials: serializeCredentials((server as JsonObject)['credentials']),
+    credentials: serializeCredentials(server.credentials),
     credential_values: matchedCreds,
   };
 }

--- a/src/lib/mcp/wire.ts
+++ b/src/lib/mcp/wire.ts
@@ -184,3 +184,134 @@ export function serializeMcpServerWithCreds(server: MCPServerProtocol): JsonObje
 
   return result;
 }
+
+// --- Connection Serialization ---
+
+/** Serialize a Connection object to wire format. */
+export function serializeConnection(connection: unknown): JsonObject {
+  if (connection != null && typeof connection === 'object') {
+    if ('toDict' in connection && typeof (connection as JsonObject)['toDict'] === 'function') {
+      return (connection as { toDict(): JsonObject }).toDict();
+    }
+    if (connection instanceof Object && !Array.isArray(connection) && 'name' in connection) {
+      // Check if it's a plain dict
+      const proto = Object.getPrototypeOf(connection);
+      if (proto === Object.prototype || proto === null) {
+        return connection as JsonObject;
+      }
+    }
+  }
+  // Duck-type extraction
+  const obj = connection as JsonObject;
+  return {
+    name: obj?.['name'] ?? 'unknown',
+    base_url: obj?.['base_url'] ?? obj?.['baseUrl'] ?? null,
+    timeout_ms: obj?.['timeout_ms'] ?? obj?.['timeoutMs'] ?? 30000,
+  };
+}
+
+/** Collect unique connections from multiple MCPServer instances. */
+export function collectUniqueConnections(servers: unknown[]): unknown[] {
+  const seenNames = new Set<string>();
+  const unique: unknown[] = [];
+
+  for (const server of servers) {
+    const serverObj = server as JsonObject;
+    const connections = serverObj['connections'];
+    if (connections == null) continue;
+
+    const connList: unknown[] =
+      Array.isArray(connections) ? connections
+      : typeof connections === 'object' ? Object.values(connections as JsonObject)
+      : [];
+
+    for (const conn of connList) {
+      let name: string | null = null;
+      if (conn != null && typeof conn === 'object') {
+        name = (conn as JsonObject)['name'] as string | null;
+      }
+      if (name && !seenNames.has(name)) {
+        seenNames.add(name);
+        unique.push(conn);
+      }
+    }
+  }
+
+  return unique;
+}
+
+// --- Credential Matching ---
+
+/** Match Credential objects to their Connection definitions. */
+export function matchCredentialsToConnections(
+  connections: unknown[],
+  credentials: unknown[],
+): ConnectionCredentialPair[] {
+  // Build lookup by connection name
+  const credsByName = new Map<string, unknown>();
+  for (const cred of credentials) {
+    let name: string | null = null;
+    if (cred != null && typeof cred === 'object') {
+      const c = cred as JsonObject;
+      if ('connection' in c && c['connection'] != null && typeof c['connection'] === 'object') {
+        name = (c['connection'] as JsonObject)['name'] as string | null;
+      } else if ('connection_name' in c) {
+        name = c['connection_name'] as string | null;
+      }
+    }
+    if (name) credsByName.set(name, cred);
+  }
+
+  const pairs: ConnectionCredentialPair[] = [];
+  const missing: string[] = [];
+
+  for (const conn of connections) {
+    let name: string | null = null;
+    if (conn != null && typeof conn === 'object') {
+      name = (conn as JsonObject)['name'] as string | null;
+    }
+    if (name && credsByName.has(name)) {
+      pairs.push([conn, credsByName.get(name) as CredentialProtocol]);
+    } else if (name) {
+      missing.push(name);
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing credentials for connections: ${JSON.stringify(missing.sort())}. ` +
+        'Each Connection declared in mcp_servers must have a corresponding Credential.',
+    );
+  }
+
+  return pairs;
+}
+
+/** Validate that all connections across servers have credentials. */
+export function validateCredentialsForServers(
+  servers: unknown[],
+  credentials: unknown[],
+): ConnectionCredentialPair[] {
+  const connections = collectUniqueConnections(servers);
+  return matchCredentialsToConnections(connections, credentials);
+}
+
+/** Build a connection record. */
+export function buildConnectionRecord(
+  server: MCPServerProtocol,
+  credentials: Record<string, JsonObject>,
+  orgId: string,
+): JsonObject {
+  const connection = (server as JsonObject)['connection'] as string | null;
+  let matchedCreds: JsonObject | null = null;
+  if (connection && connection in credentials) {
+    matchedCreds = credentials[connection]!;
+  }
+
+  return {
+    org_id: orgId,
+    connection,
+    credentials: serializeCredentials((server as JsonObject)['credentials']),
+    credential_values: matchedCreds,
+  };
+}

--- a/src/lib/mcp/wire.ts
+++ b/src/lib/mcp/wire.ts
@@ -21,6 +21,11 @@ export type ConnectionCredentialPair = [connection: unknown, credential: Credent
 
 // --- Wire Format ---
 
+/** Derive canonical connection name from a server slug (org/server → org-server). */
+export function slugToConnectionName(slug: string): string {
+  return slug.replace(/\//g, '-');
+}
+
 const SLUG_PATTERN = /^[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+$/;
 
 export interface MCPServerWireSpecFields {

--- a/tests/lib/mcp/connections.test.ts
+++ b/tests/lib/mcp/connections.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for Connection/Credential wire format serialization.
+ * Port of: dedalus-sdk-python/tests/test_mcp_wire_connections.py
+ */
+
+import {
+  serializeConnection,
+  collectUniqueConnections,
+  matchCredentialsToConnections,
+  validateCredentialsForServers,
+} from '../../../src/lib/mcp';
+
+// --- Mock objects ---
+
+class MockConnection {
+  private _name: string;
+  private _baseUrl: string | null;
+  private _timeoutMs: number;
+
+  constructor(name: string, baseUrl?: string | null, timeoutMs = 30000) {
+    this._name = name;
+    this._baseUrl = baseUrl ?? null;
+    this._timeoutMs = timeoutMs;
+  }
+
+  get name() {
+    return this._name;
+  }
+  get base_url() {
+    return this._baseUrl;
+  }
+  get timeout_ms() {
+    return this._timeoutMs;
+  }
+
+  toDict(): Record<string, unknown> {
+    const result: Record<string, unknown> = { name: this._name };
+    if (this._baseUrl != null) result['base_url'] = this._baseUrl;
+    if (this._timeoutMs !== 30000) result['timeout_ms'] = this._timeoutMs;
+    return result;
+  }
+}
+
+class MockCredential {
+  private _connection: MockConnection;
+  private _values: Record<string, unknown>;
+
+  constructor(connection: MockConnection, values: Record<string, unknown>) {
+    this._connection = connection;
+    this._values = values;
+  }
+
+  get connection() {
+    return this._connection;
+  }
+  get values() {
+    return { ...this._values };
+  }
+
+  toDict(): Record<string, unknown> {
+    return { connection_name: this._connection.name, values: { ...this._values } };
+  }
+
+  valuesForEncryption(): Record<string, unknown> {
+    return { ...this._values };
+  }
+}
+
+class MockServer {
+  name: string;
+  connections: unknown[];
+  constructor(name: string, connections?: unknown[]) {
+    this.name = name;
+    this.connections = connections ?? [];
+  }
+}
+
+// --- TestSerializeConnection ---
+
+describe('TestSerializeConnection', () => {
+  test('with connection object (toDict)', () => {
+    const conn = new MockConnection('github', 'https://api.github.com', 60000);
+    const result = serializeConnection(conn);
+    expect(result['name']).toBe('github');
+    expect(result['base_url']).toBe('https://api.github.com');
+    expect(result['timeout_ms']).toBe(60000);
+  });
+
+  test('with dict passthrough', () => {
+    const data = { name: 'dedalus', base_url: 'https://api.dedaluslabs.ai/v1' };
+    const result = serializeConnection(data);
+    expect(result).toEqual(data);
+  });
+
+  test('duck type extraction', () => {
+    class BareConnection {
+      name = 'bare';
+      base_url = 'https://bare.api.com';
+      timeout_ms = 15000;
+    }
+    const result = serializeConnection(new BareConnection());
+    expect(result['name']).toBe('bare');
+    expect(result['base_url']).toBe('https://bare.api.com');
+    expect(result['timeout_ms']).toBe(15000);
+  });
+});
+
+// --- TestMatchCredentialsToConnections ---
+
+describe('TestMatchCredentialsToConnections', () => {
+  test('basic matching by name', () => {
+    const github = new MockConnection('github');
+    const dedalus = new MockConnection('dedalus');
+
+    const githubSecret = new MockCredential(github, { token: 'ghp_xxx' });
+    const dedalusSecret = new MockCredential(dedalus, { api_key: 'sk_xxx' });
+
+    const pairs = matchCredentialsToConnections(
+      [github, dedalus],
+      [dedalusSecret, githubSecret], // Different order
+    );
+
+    expect(pairs).toHaveLength(2);
+    expect((pairs[0]![0] as MockConnection).name).toBe('github');
+    expect((pairs[0]![1] as MockCredential).values).toEqual({ token: 'ghp_xxx' });
+    expect((pairs[1]![0] as MockConnection).name).toBe('dedalus');
+    expect((pairs[1]![1] as MockCredential).values).toEqual({ api_key: 'sk_xxx' });
+  });
+
+  test('missing secret raises error', () => {
+    const github = new MockConnection('github');
+    const dedalus = new MockConnection('dedalus');
+
+    const githubSecret = new MockCredential(github, { token: 'ghp_xxx' });
+
+    expect(() => matchCredentialsToConnections([github, dedalus], [githubSecret])).toThrow(
+      /Missing credentials.*dedalus/,
+    );
+  });
+
+  test('with dict inputs', () => {
+    const connections = [{ name: 'api' }];
+    const secrets = [{ connection_name: 'api', values: { key: 'xxx' } }];
+
+    const pairs = matchCredentialsToConnections(connections, secrets);
+
+    expect(pairs).toHaveLength(1);
+    expect((pairs[0]![0] as Record<string, unknown>)['name']).toBe('api');
+    expect((pairs[0]![1] as Record<string, unknown>)['values']).toEqual({ key: 'xxx' });
+  });
+
+  test('missing multiple secrets lists all', () => {
+    const github = new MockConnection('github');
+    const dedalus = new MockConnection('dedalus');
+    const slack = new MockConnection('slack');
+
+    const githubSecret = new MockCredential(github, { token: 'ghp_xxx' });
+
+    expect(() => matchCredentialsToConnections([github, dedalus, slack], [githubSecret])).toThrow(/dedalus/);
+    expect(() => matchCredentialsToConnections([github, dedalus, slack], [githubSecret])).toThrow(/slack/);
+  });
+});
+
+// --- TestCollectUniqueConnections ---
+
+describe('TestCollectUniqueConnections', () => {
+  test('single server', () => {
+    const github = new MockConnection('github');
+    const dedalus = new MockConnection('dedalus');
+    const server = new MockServer('bot', [github, dedalus]);
+
+    const result = collectUniqueConnections([server]);
+
+    expect(result).toHaveLength(2);
+    expect((result[0] as MockConnection).name).toBe('github');
+    expect((result[1] as MockConnection).name).toBe('dedalus');
+  });
+
+  test('shared connection deduplicated', () => {
+    const github = new MockConnection('github');
+
+    const serverA = new MockServer('issues', [github]);
+    const serverB = new MockServer('prs', [github]);
+
+    const result = collectUniqueConnections([serverA, serverB]);
+
+    expect(result).toHaveLength(1);
+    expect((result[0] as MockConnection).name).toBe('github');
+  });
+
+  test('same name different objects', () => {
+    const githubA = new MockConnection('github', 'https://api.github.com');
+    const githubB = new MockConnection('github', 'https://api.github.com');
+
+    const serverA = new MockServer('a', [githubA]);
+    const serverB = new MockServer('b', [githubB]);
+
+    const result = collectUniqueConnections([serverA, serverB]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(githubA); // First occurrence kept
+  });
+
+  test('multiple servers multiple connections', () => {
+    const github = new MockConnection('github');
+    const dedalus = new MockConnection('dedalus');
+    const slack = new MockConnection('slack');
+
+    const serverA = new MockServer('bot1', [github, dedalus]);
+    const serverB = new MockServer('bot2', [github, slack]);
+
+    const result = collectUniqueConnections([serverA, serverB]);
+
+    expect(result).toHaveLength(3);
+    const names = result.map((c) => (c as MockConnection).name);
+    expect(names).toEqual(['github', 'dedalus', 'slack']);
+  });
+
+  test('server without connections', () => {
+    const serverA = new MockServer('empty');
+    const serverB = new MockServer('has', [new MockConnection('api')]);
+
+    const result = collectUniqueConnections([serverA, serverB]);
+
+    expect(result).toHaveLength(1);
+  });
+});
+
+// --- TestValidateCredentialsForServers ---
+
+describe('TestValidateCredentialsForServers', () => {
+  test('all connections have secrets', () => {
+    const github = new MockConnection('github');
+    const dedalus = new MockConnection('dedalus');
+
+    const server = new MockServer('bot', [github, dedalus]);
+
+    const githubSecret = new MockCredential(github, { token: 'ghp_xxx' });
+    const dedalusSecret = new MockCredential(dedalus, { api_key: 'sk_xxx' });
+
+    const pairs = validateCredentialsForServers([server], [githubSecret, dedalusSecret]);
+
+    expect(pairs).toHaveLength(2);
+  });
+
+  test('shared connection one secret', () => {
+    const github = new MockConnection('github');
+
+    const serverA = new MockServer('issues', [github]);
+    const serverB = new MockServer('prs', [github]);
+
+    const githubSecret = new MockCredential(github, { token: 'ghp_xxx' });
+
+    const pairs = validateCredentialsForServers([serverA, serverB], [githubSecret]);
+
+    expect(pairs).toHaveLength(1);
+    expect((pairs[0]![0] as MockConnection).name).toBe('github');
+  });
+
+  test('missing secret fails fast', () => {
+    const github = new MockConnection('github');
+    const dedalus = new MockConnection('dedalus');
+
+    const server = new MockServer('bot', [github, dedalus]);
+    const githubSecret = new MockCredential(github, { token: 'ghp_xxx' });
+
+    expect(() => validateCredentialsForServers([server], [githubSecret])).toThrow(/dedalus/);
+    expect(() => validateCredentialsForServers([server], [githubSecret])).toThrow(/Missing credentials/);
+  });
+});

--- a/tests/lib/mcp/connections.test.ts
+++ b/tests/lib/mcp/connections.test.ts
@@ -146,7 +146,7 @@ describe('TestMatchCredentialsToConnections', () => {
 
     expect(pairs).toHaveLength(1);
     expect((pairs[0]![0] as Record<string, unknown>)['name']).toBe('api');
-    expect((pairs[0]![1] as Record<string, unknown>)['values']).toEqual({ key: 'xxx' });
+    expect((pairs[0]![1] as unknown as Record<string, unknown>)['values']).toEqual({ key: 'xxx' });
   });
 
   test('missing multiple secrets lists all', () => {

--- a/tests/lib/mcp/request.test.ts
+++ b/tests/lib/mcp/request.test.ts
@@ -140,6 +140,35 @@ describe('TestPrepareMcpRequest', () => {
     expect(decrypted).toEqual({ key: 'sk_test' });
   });
 
+  test('credential connection_name slugs are normalized for lookup', async () => {
+    const mockFetch = createMockFetch(jwk);
+    const data: Record<string, unknown> = {
+      mcp_servers: ['org/server'],
+      credentials: [{ connection_name: 'org/server', values: { key: 'sk_test' } }],
+    };
+
+    const result = await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+
+    const servers = result['mcp_servers'] as Record<string, unknown>[];
+    const creds = servers[0]!['credentials'] as Record<string, string>;
+    expect(Object.keys(creds)).toEqual(['org-server']);
+    const decrypted = await decryptEnvelope(privateKey, creds['org-server']!, 2048);
+    expect(decrypted).toEqual({ key: 'sk_test' });
+  });
+
+  test('invalid credential entries are stripped from plaintext payload', async () => {
+    const mockFetch = createMockFetch(jwk);
+    const data: Record<string, unknown> = {
+      mcp_servers: ['org/server'],
+      credentials: [{ connection_name: 'org-server' }],
+    };
+
+    const result = await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+
+    expect(result['credentials']).toBeUndefined();
+    expect(result['mcp_servers']).toEqual(['org/server']);
+  });
+
   test('no credentials → passthrough', async () => {
     const data = { model: 'openai/gpt-4o-mini', mcp_servers: ['org/server'] };
     const result = await prepareMcpRequest(data, 'https://as.example.com');
@@ -182,6 +211,20 @@ describe('TestPrepareMcpRequest', () => {
     // Mutation of result doesn't affect original nested objects
     (result['extra'] as Record<string, unknown>)['nested'] = 'mutated';
     expect((data['extra'] as Record<string, unknown>)['nested']).toBe('value');
+  });
+
+  test('encryption path does not mutate input mcp_servers', async () => {
+    const mockFetch = createMockFetch(jwk);
+    const data: Record<string, unknown> = {
+      mcp_servers: ['org/server@v2'],
+      credentials: [{ connection: { name: 'org-server' }, valuesForEncryption: () => ({ key: 'secret' }) }],
+    };
+    const originalServers = data['mcp_servers'];
+
+    await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+
+    expect(data['mcp_servers']).toBe(originalServers);
+    expect(data['mcp_servers']).toEqual(['org/server@v2']);
   });
 
   test('JWKS fetch error propagates', async () => {

--- a/tests/lib/mcp/request.test.ts
+++ b/tests/lib/mcp/request.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Tests for MCP request preparation orchestrator.
+ * Tests prepareMcpRequest, encryptCredentialsList, embedCredentials.
+ */
+
+import { prepareMcpRequest, embedCredentials, slugToConnectionName } from '../../../src/lib/mcp';
+import { b64urlDecode, NONCE_LEN } from '../../../src/lib/crypto/encryption';
+
+const RSA_ALGORITHM = { name: 'RSA-OAEP', hash: 'SHA-256' } as const;
+
+let privateKey: CryptoKey;
+let publicKey: CryptoKey;
+let jwk: JsonWebKey;
+
+// Mock fetch that returns JWKS
+function createMockFetch(jwkKey: JsonWebKey): typeof fetch {
+  return (async (_url: string | URL | Request) => {
+    return new Response(JSON.stringify({ keys: [{ ...jwkKey, use: 'enc', kid: 'test-1' }] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof fetch;
+}
+
+async function decryptEnvelope(
+  privKey: CryptoKey,
+  b64: string,
+  keySize: number,
+): Promise<Record<string, unknown>> {
+  const envelope = b64urlDecode(b64);
+  const keySizeBytes = keySize / 8;
+  const wrappedKey = envelope.slice(1, 1 + keySizeBytes);
+  const nonce = envelope.slice(1 + keySizeBytes, 1 + keySizeBytes + NONCE_LEN);
+  const ct = envelope.slice(1 + keySizeBytes + NONCE_LEN);
+  const aesKeyRaw = await crypto.subtle.decrypt(RSA_ALGORITHM, privKey, wrappedKey);
+  const aesKey = await crypto.subtle.importKey('raw', aesKeyRaw, { name: 'AES-GCM' }, false, ['decrypt']);
+  const pt = await crypto.subtle.decrypt({ name: 'AES-GCM', iv: nonce }, aesKey, ct);
+  return JSON.parse(new TextDecoder().decode(pt));
+}
+
+beforeAll(async () => {
+  const kp = await crypto.subtle.generateKey(
+    { name: 'RSA-OAEP', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+    true,
+    ['encrypt', 'decrypt'],
+  );
+  privateKey = kp.privateKey;
+  publicKey = kp.publicKey;
+  jwk = await crypto.subtle.exportKey('jwk', publicKey);
+});
+
+// --- TestPrepareMcpRequest ---
+
+describe('TestPrepareMcpRequest', () => {
+  test('full orchestration: encrypt, embed, strip plaintext', async () => {
+    const mockFetch = createMockFetch(jwk);
+    const data: Record<string, unknown> = {
+      model: 'openai/gpt-4o-mini',
+      mcp_servers: ['org/server'],
+      credentials: [
+        { connection: { name: 'org-server' }, valuesForEncryption: () => ({ token: 'ghp_xxx' }) },
+      ],
+    };
+
+    const result = await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+
+    // credentials field removed
+    expect(result['credentials']).toBeUndefined();
+    // mcp_servers converted to spec dicts with scoped credentials
+    const servers = result['mcp_servers'] as Record<string, unknown>[];
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!['slug']).toBe('org/server');
+    expect(servers[0]!['credentials']).toBeDefined();
+
+    // Verify per-server scoping: only org-server credential present
+    const creds = servers[0]!['credentials'] as Record<string, string>;
+    expect(Object.keys(creds)).toEqual(['org-server']);
+    const decrypted = await decryptEnvelope(privateKey, creds['org-server']!, 2048);
+    expect(decrypted).toEqual({ token: 'ghp_xxx' });
+  });
+
+  test('single credential object normalized to array', async () => {
+    const mockFetch = createMockFetch(jwk);
+    const data: Record<string, unknown> = {
+      mcp_servers: ['org/server'],
+      credentials: { connection: { name: 'org-server' }, valuesForEncryption: () => ({ key: 'sk_xxx' }) },
+    };
+
+    const result = await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+
+    expect(result['credentials']).toBeUndefined();
+    const servers = result['mcp_servers'] as Record<string, unknown>[];
+    const creds = servers[0]!['credentials'] as Record<string, string>;
+    expect(creds['org-server']).toBeDefined();
+  });
+
+  test('multi-server: each server gets only its own credential', async () => {
+    const mockFetch = createMockFetch(jwk);
+    const data: Record<string, unknown> = {
+      mcp_servers: ['acme/github', 'acme/slack'],
+      credentials: [
+        { connection: { name: 'acme-github' }, valuesForEncryption: () => ({ token: 'ghp_xxx' }) },
+        {
+          connection: { name: 'acme-slack' },
+          valuesForEncryption: () => ({ webhook: 'https://hooks.slack.com/xxx' }),
+        },
+      ],
+    };
+
+    const result = await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+
+    const servers = result['mcp_servers'] as Record<string, unknown>[];
+    expect(servers).toHaveLength(2);
+
+    // First server gets only github credential
+    const ghCreds = servers[0]!['credentials'] as Record<string, string>;
+    expect(Object.keys(ghCreds)).toEqual(['acme-github']);
+    const gh = await decryptEnvelope(privateKey, ghCreds['acme-github']!, 2048);
+    expect(gh).toEqual({ token: 'ghp_xxx' });
+
+    // Second server gets only slack credential
+    const slCreds = servers[1]!['credentials'] as Record<string, string>;
+    expect(Object.keys(slCreds)).toEqual(['acme-slack']);
+    const sl = await decryptEnvelope(privateKey, slCreds['acme-slack']!, 2048);
+    expect(sl).toEqual({ webhook: 'https://hooks.slack.com/xxx' });
+  });
+
+  test('plain Credential dicts work', async () => {
+    const mockFetch = createMockFetch(jwk);
+    const data: Record<string, unknown> = {
+      mcp_servers: ['org/server'],
+      credentials: [{ connection_name: 'org-server', values: { key: 'sk_test' } }],
+    };
+
+    const result = await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+
+    const servers = result['mcp_servers'] as Record<string, unknown>[];
+    const creds = servers[0]!['credentials'] as Record<string, string>;
+    const decrypted = await decryptEnvelope(privateKey, creds['org-server']!, 2048);
+    expect(decrypted).toEqual({ key: 'sk_test' });
+  });
+
+  test('no credentials → passthrough', async () => {
+    const data = { model: 'openai/gpt-4o-mini', mcp_servers: ['org/server'] };
+    const result = await prepareMcpRequest(data, 'https://as.example.com');
+
+    expect(result['mcp_servers']).toEqual(['org/server']);
+  });
+
+  test('no mcp_servers → passthrough', async () => {
+    const data = {
+      model: 'openai/gpt-4o-mini',
+      credentials: [{ connection_name: 'api', values: { key: 'x' } }],
+    };
+    const result = await prepareMcpRequest(data, 'https://as.example.com');
+
+    expect(result['credentials']).toBeDefined(); // Not stripped since no servers
+  });
+
+  test('no asUrl → passthrough', async () => {
+    const data: Record<string, unknown> = {
+      mcp_servers: ['org/server'],
+      credentials: [{ connection_name: 'api', values: { key: 'x' } }],
+    };
+    const result = await prepareMcpRequest(data, null);
+
+    expect(result['credentials']).toBeDefined();
+  });
+
+  test('deep clone protects original data', async () => {
+    const mockFetch = createMockFetch(jwk);
+    const data: Record<string, unknown> = {
+      mcp_servers: ['org/server'],
+      credentials: [{ connection: { name: 'org-server' }, valuesForEncryption: () => ({ key: 'secret' }) }],
+      extra: { nested: 'value' },
+    };
+
+    const result = await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+
+    // Result is a separate object
+    expect(result).not.toBe(data);
+    // Mutation of result doesn't affect original nested objects
+    (result['extra'] as Record<string, unknown>)['nested'] = 'mutated';
+    expect((data['extra'] as Record<string, unknown>)['nested']).toBe('value');
+  });
+
+  test('JWKS fetch error propagates', async () => {
+    const failFetch = (async () => new Response('', { status: 500 })) as typeof fetch;
+    const data: Record<string, unknown> = {
+      mcp_servers: ['org/server'],
+      credentials: [{ connection_name: 'api', values: { key: 'x' } }],
+    };
+
+    await expect(prepareMcpRequest(data, 'https://as.example.com', failFetch)).rejects.toThrow(
+      'failed to fetch JWKS',
+    );
+  });
+
+  test('no suitable RSA enc key throws', async () => {
+    const noKeyFetch = (async () =>
+      new Response(JSON.stringify({ keys: [{ kty: 'EC', use: 'sig' }] }), {
+        status: 200,
+      })) as typeof fetch;
+    const data: Record<string, unknown> = {
+      mcp_servers: ['org/server'],
+      credentials: [{ connection_name: 'api', values: { key: 'x' } }],
+    };
+
+    await expect(prepareMcpRequest(data, 'https://as.example.com', noKeyFetch)).rejects.toThrow(
+      'no RSA encryption key found',
+    );
+  });
+});
+
+// --- TestSlugToConnectionName ---
+
+describe('TestSlugToConnectionName', () => {
+  test('replaces slash with dash', () => {
+    expect(slugToConnectionName('org/server')).toBe('org-server');
+  });
+
+  test('no slash passes through', () => {
+    expect(slugToConnectionName('plain-name')).toBe('plain-name');
+  });
+
+  test('URL passes through with slash replaced', () => {
+    expect(slugToConnectionName('https://example.com/mcp')).toBe('https:--example.com-mcp');
+  });
+});
+
+// --- TestEmbedCredentials ---
+
+describe('TestEmbedCredentials', () => {
+  // Connection names use slugToConnectionName: org/server → org-server
+  const encrypted = { 'org-server': 'encrypted_blob_1', 'acme-slack': 'encrypted_blob_2' };
+
+  test('slug string gets only its own credential', () => {
+    const result = embedCredentials(['org/server'], encrypted);
+    expect(result[0]).toEqual({
+      slug: 'org/server',
+      name: 'org/server',
+      credentials: { 'org-server': 'encrypted_blob_1' },
+    });
+  });
+
+  test('multi-server: each gets only its own credential', () => {
+    const result = embedCredentials(['org/server', 'acme/slack'], encrypted);
+    expect(result[0]!['credentials']).toEqual({ 'org-server': 'encrypted_blob_1' });
+    expect(result[1]!['credentials']).toEqual({ 'acme-slack': 'encrypted_blob_2' });
+  });
+
+  test('unmatched server gets null credentials', () => {
+    const result = embedCredentials(['unknown/other'], encrypted);
+    expect(result[0]!['credentials']).toBeNull();
+  });
+
+  test('URL string gets scoped credentials', () => {
+    const urlCreds = { 'https:--mcp.example.com-server': 'blob_url' };
+    const result = embedCredentials(['https://mcp.example.com/server'], urlCreds);
+    expect(result[0]).toEqual({
+      url: 'https://mcp.example.com/server',
+      name: 'https://mcp.example.com/server',
+      credentials: { 'https:--mcp.example.com-server': 'blob_url' },
+    });
+  });
+
+  test('dict spec gets scoped credentials', () => {
+    const result = embedCredentials([{ slug: 'org/server', version: 'v2' }], encrypted);
+    expect(result[0]).toEqual({
+      slug: 'org/server',
+      version: 'v2',
+      name: 'org/server',
+      credentials: { 'org-server': 'encrypted_blob_1' },
+    });
+  });
+
+  test('name derived from slug/url/name field', () => {
+    const r1 = embedCredentials([{ slug: 'org/server' }], encrypted);
+    expect(r1[0]!['name']).toBe('org/server');
+
+    const r2 = embedCredentials([{ url: 'https://x.com/mcp' }], encrypted);
+    expect(r2[0]!['name']).toBe('https://x.com/mcp');
+
+    const r3 = embedCredentials([{ slug: 'org/server', name: 'custom' }], encrypted);
+    expect(r3[0]!['name']).toBe('custom');
+  });
+
+  test('dict with custom name uses name for credential lookup', () => {
+    const creds = { custom: 'blob_custom' };
+    const result = embedCredentials([{ slug: 'org/server', name: 'custom' }], creds);
+    expect(result[0]!['credentials']).toEqual({ custom: 'blob_custom' });
+  });
+});

--- a/tests/lib/mcp/request.test.ts
+++ b/tests/lib/mcp/request.test.ts
@@ -5,6 +5,8 @@
 
 import { prepareMcpRequest, embedCredentials, slugToConnectionName } from '../../../src/lib/mcp';
 import { b64urlDecode, NONCE_LEN } from '../../../src/lib/crypto/encryption';
+import { type CryptoKey, type JsonWebKey } from '../../../src/lib/crypto/types';
+import { type JsonObject } from '../../../src/lib/utils/json';
 
 const RSA_ALGORITHM = { name: 'RSA-OAEP', hash: 'SHA-256' } as const;
 
@@ -22,11 +24,7 @@ function createMockFetch(jwkKey: JsonWebKey): typeof fetch {
   }) as typeof fetch;
 }
 
-async function decryptEnvelope(
-  privKey: CryptoKey,
-  b64: string,
-  keySize: number,
-): Promise<Record<string, unknown>> {
+async function decryptEnvelope(privKey: CryptoKey, b64: string, keySize: number): Promise<JsonObject> {
   const envelope = b64urlDecode(b64);
   const keySizeBytes = keySize / 8;
   const wrappedKey = envelope.slice(1, 1 + keySizeBytes);
@@ -62,12 +60,16 @@ describe('TestPrepareMcpRequest', () => {
       ],
     };
 
-    const result = await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+    const result = await prepareMcpRequest(
+      data as unknown as JsonObject,
+      'https://as.example.com',
+      mockFetch,
+    );
 
     // credentials field removed
     expect(result['credentials']).toBeUndefined();
     // mcp_servers converted to spec dicts with scoped credentials
-    const servers = result['mcp_servers'] as Record<string, unknown>[];
+    const servers = result['mcp_servers'] as JsonObject[];
     expect(servers).toHaveLength(1);
     expect(servers[0]!['slug']).toBe('org/server');
     expect(servers[0]!['credentials']).toBeDefined();
@@ -86,10 +88,14 @@ describe('TestPrepareMcpRequest', () => {
       credentials: { connection: { name: 'org-server' }, valuesForEncryption: () => ({ key: 'sk_xxx' }) },
     };
 
-    const result = await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+    const result = await prepareMcpRequest(
+      data as unknown as JsonObject,
+      'https://as.example.com',
+      mockFetch,
+    );
 
     expect(result['credentials']).toBeUndefined();
-    const servers = result['mcp_servers'] as Record<string, unknown>[];
+    const servers = result['mcp_servers'] as JsonObject[];
     const creds = servers[0]!['credentials'] as Record<string, string>;
     expect(creds['org-server']).toBeDefined();
   });
@@ -107,9 +113,13 @@ describe('TestPrepareMcpRequest', () => {
       ],
     };
 
-    const result = await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+    const result = await prepareMcpRequest(
+      data as unknown as JsonObject,
+      'https://as.example.com',
+      mockFetch,
+    );
 
-    const servers = result['mcp_servers'] as Record<string, unknown>[];
+    const servers = result['mcp_servers'] as JsonObject[];
     expect(servers).toHaveLength(2);
 
     // First server gets only github credential
@@ -132,9 +142,13 @@ describe('TestPrepareMcpRequest', () => {
       credentials: [{ connection_name: 'org-server', values: { key: 'sk_test' } }],
     };
 
-    const result = await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+    const result = await prepareMcpRequest(
+      data as unknown as JsonObject,
+      'https://as.example.com',
+      mockFetch,
+    );
 
-    const servers = result['mcp_servers'] as Record<string, unknown>[];
+    const servers = result['mcp_servers'] as JsonObject[];
     const creds = servers[0]!['credentials'] as Record<string, string>;
     const decrypted = await decryptEnvelope(privateKey, creds['org-server']!, 2048);
     expect(decrypted).toEqual({ key: 'sk_test' });
@@ -147,9 +161,13 @@ describe('TestPrepareMcpRequest', () => {
       credentials: [{ connection_name: 'org/server', values: { key: 'sk_test' } }],
     };
 
-    const result = await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+    const result = await prepareMcpRequest(
+      data as unknown as JsonObject,
+      'https://as.example.com',
+      mockFetch,
+    );
 
-    const servers = result['mcp_servers'] as Record<string, unknown>[];
+    const servers = result['mcp_servers'] as JsonObject[];
     const creds = servers[0]!['credentials'] as Record<string, string>;
     expect(Object.keys(creds)).toEqual(['org-server']);
     const decrypted = await decryptEnvelope(privateKey, creds['org-server']!, 2048);
@@ -163,7 +181,11 @@ describe('TestPrepareMcpRequest', () => {
       credentials: [{ connection_name: 'org-server' }],
     };
 
-    const result = await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+    const result = await prepareMcpRequest(
+      data as unknown as JsonObject,
+      'https://as.example.com',
+      mockFetch,
+    );
 
     expect(result['credentials']).toBeUndefined();
     expect(result['mcp_servers']).toEqual(['org/server']);
@@ -171,7 +193,7 @@ describe('TestPrepareMcpRequest', () => {
 
   test('no credentials → passthrough', async () => {
     const data = { model: 'openai/gpt-4o-mini', mcp_servers: ['org/server'] };
-    const result = await prepareMcpRequest(data, 'https://as.example.com');
+    const result = await prepareMcpRequest(data as unknown as JsonObject, 'https://as.example.com');
 
     expect(result['mcp_servers']).toEqual(['org/server']);
   });
@@ -181,7 +203,7 @@ describe('TestPrepareMcpRequest', () => {
       model: 'openai/gpt-4o-mini',
       credentials: [{ connection_name: 'api', values: { key: 'x' } }],
     };
-    const result = await prepareMcpRequest(data, 'https://as.example.com');
+    const result = await prepareMcpRequest(data as unknown as JsonObject, 'https://as.example.com');
 
     expect(result['credentials']).toBeDefined(); // Not stripped since no servers
   });
@@ -191,7 +213,7 @@ describe('TestPrepareMcpRequest', () => {
       mcp_servers: ['org/server'],
       credentials: [{ connection_name: 'api', values: { key: 'x' } }],
     };
-    const result = await prepareMcpRequest(data, null);
+    const result = await prepareMcpRequest(data as unknown as JsonObject, null);
 
     expect(result['credentials']).toBeDefined();
   });
@@ -204,13 +226,17 @@ describe('TestPrepareMcpRequest', () => {
       extra: { nested: 'value' },
     };
 
-    const result = await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+    const result = await prepareMcpRequest(
+      data as unknown as JsonObject,
+      'https://as.example.com',
+      mockFetch,
+    );
 
     // Result is a separate object
     expect(result).not.toBe(data);
     // Mutation of result doesn't affect original nested objects
-    (result['extra'] as Record<string, unknown>)['nested'] = 'mutated';
-    expect((data['extra'] as Record<string, unknown>)['nested']).toBe('value');
+    (result['extra'] as JsonObject)['nested'] = 'mutated';
+    expect((data['extra'] as JsonObject)['nested']).toBe('value');
   });
 
   test('encryption path does not mutate input mcp_servers', async () => {
@@ -221,7 +247,7 @@ describe('TestPrepareMcpRequest', () => {
     };
     const originalServers = data['mcp_servers'];
 
-    await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+    await prepareMcpRequest(data as unknown as JsonObject, 'https://as.example.com', mockFetch);
 
     expect(data['mcp_servers']).toBe(originalServers);
     expect(data['mcp_servers']).toEqual(['org/server@v2']);
@@ -234,9 +260,9 @@ describe('TestPrepareMcpRequest', () => {
       credentials: [{ connection_name: 'api', values: { key: 'x' } }],
     };
 
-    await expect(prepareMcpRequest(data, 'https://as.example.com', failFetch)).rejects.toThrow(
-      'failed to fetch JWKS',
-    );
+    await expect(
+      prepareMcpRequest(data as unknown as JsonObject, 'https://as.example.com', failFetch),
+    ).rejects.toThrow('failed to fetch JWKS');
   });
 
   test('no suitable RSA enc key throws', async () => {
@@ -249,9 +275,9 @@ describe('TestPrepareMcpRequest', () => {
       credentials: [{ connection_name: 'api', values: { key: 'x' } }],
     };
 
-    await expect(prepareMcpRequest(data, 'https://as.example.com', noKeyFetch)).rejects.toThrow(
-      'no RSA encryption key found',
-    );
+    await expect(
+      prepareMcpRequest(data as unknown as JsonObject, 'https://as.example.com', noKeyFetch),
+    ).rejects.toThrow('no RSA encryption key found');
   });
 });
 


### PR DESCRIPTION
## Summary
- Merge the MCP wire/connections stack into `next`.
- Brings in per-server credential matching and request preparation support needed by downstream MCP client flow.

## Included commits
- feat: add connection serialization and credential matching
- feat: add MCP request preparation with per-server credential scoping

## Validation
- Existing PR-level tests for these commits passed during implementation.

## Notes
- This PR is an integration merge from the stacked branch to `next`.
